### PR TITLE
Ensure zsh config files get correct ownership

### DIFF
--- a/archinstall.sh
+++ b/archinstall.sh
@@ -513,7 +513,7 @@ HISTFILE=~/.zsh_history
 setopt appendhistory
 PS1='%n@%m:%~$ '
 EOF
-            chown 1000:1000 "$MOUNT_POINT/home/$USERNAME/.zshrc"
+            arch-chroot "$MOUNT_POINT" chown "$USERNAME:$USERNAME" "/home/$USERNAME/.zshrc"
             ;;
         fish)
             mkdir -p "$MOUNT_POINT/home/$USERNAME/.config/fish"

--- a/archinstall_new.sh
+++ b/archinstall_new.sh
@@ -513,7 +513,7 @@ HISTFILE=~/.zsh_history
 setopt appendhistory
 PS1='%n@%m:%~$ '
 EOF
-            chown 1000:1000 "$MOUNT_POINT/home/$USERNAME/.zshrc"
+            arch-chroot "$MOUNT_POINT" chown "$USERNAME:$USERNAME" "/home/$USERNAME/.zshrc"
             ;;
         fish)
             mkdir -p "$MOUNT_POINT/home/$USERNAME/.config/fish"


### PR DESCRIPTION
## Summary
- fix user configuration scripts to chown .zshrc using username instead of fixed UID

## Testing
- `./run_tests.sh` *(fails: Test suite 'basic' completed with failures)*

------
https://chatgpt.com/codex/tasks/task_e_6896a46a16a08328b7ce09cce8ab8307