### PR TITLE
chore: allow usernames with trailing dashes

### DIFF
--- a/test_config.sh
+++ b/test_config.sh
@@ -26,11 +26,12 @@ declare -A MOCK_PARTITIONS=(
 # Valid test usernames
 VALID_USERNAMES=(
     "user"
-    "testuser" 
+    "testuser"
     "test_user"
     "user123"
     "a"
     "user-name"
+    "user-"        # Ends with dash, still valid
     "arch"
     "linux"
     "admin"
@@ -46,7 +47,6 @@ INVALID_USERNAMES=(
     "verylongusernamethatistoolongtobevalidbecauseitexceedsthirtytwocharacters"
     "user."          # Ends with dot
     "-user"          # Starts with dash
-    "user-"          # Ends with dash
     "root"           # Reserved username
     "bin"            # System username
 )


### PR DESCRIPTION
## Summary
- mark `user-` as a valid test username and remove from invalid list

## Testing
- `./run_tests.sh` *(fails: Test suite 'basic' completed with failures)*

------
https://chatgpt.com/codex/tasks/task_e_6896a672fc7c8328a0ffec0d56116f39