### PR TITLE
Use American spelling for color code comment

### DIFF
--- a/archinstall.sh
+++ b/archinstall.sh
@@ -12,7 +12,7 @@ readonly MOUNT_POINT="/mnt"
 readonly DEFAULT_EFI_SIZE="512M"
 readonly DEFAULT_SWAP_SIZE="2G"
 
-# Colour codes
+# Color codes
 readonly RED='\033[0;31m'
 readonly GREEN='\033[0;32m'
 readonly YELLOW='\033[1;33m'

--- a/archinstall_new.sh
+++ b/archinstall_new.sh
@@ -12,7 +12,7 @@ readonly MOUNT_POINT="/mnt"
 readonly DEFAULT_EFI_SIZE="512M"
 readonly DEFAULT_SWAP_SIZE="2G"
 
-# Colour codes
+# Color codes
 readonly RED='\033[0;31m'
 readonly GREEN='\033[0;32m'
 readonly YELLOW='\033[1;33m'


### PR DESCRIPTION
## Summary
- fix colour → color comment in archinstall scripts

## Testing
- `./run_tests.sh quick`

------
https://chatgpt.com/codex/tasks/task_e_6896a66ac7f88328a9ef328e7376c9eb