### PR TITLE
Handle aborted input in prompts

### DIFF
--- a/archinstall.sh
+++ b/archinstall.sh
@@ -59,7 +59,9 @@ yes_no_prompt() {
     local prompt="$1"
     local reply
     while true; do
-        read -rp "$prompt [y/n]: " reply
+        if ! read -rp "$prompt [y/n]: " reply; then
+            fatal "Input aborted"
+        fi
         case "$reply" in
             [Yy]) return 0 ;;
             [Nn]) return 1 ;;
@@ -80,7 +82,9 @@ select_from_menu() {
         for i in "${!options[@]}"; do
             printf '%d) %s\n' "$((i+1))" "${options[i]}"
         done
-        read -rp "Select an option (1-${num}): " choice
+        if ! read -rp "Select an option (1-${num}): " choice; then
+            fatal "Input aborted"
+        fi
         if [[ "$choice" =~ ^[0-9]+$ ]] && (( choice >= 1 && choice <= num )); then
             echo "${options[$((choice-1))]}"
             return 0
@@ -190,7 +194,9 @@ get_btrfs_layout() {
 
 get_hostname() {
     while true; do
-        read -rp "Enter hostname for this system: " HOSTNAME
+        if ! read -rp "Enter hostname for this system: " HOSTNAME; then
+            fatal "Input aborted"
+        fi
         [[ -n "$HOSTNAME" ]] || { warning "Hostname cannot be empty"; continue; }
         if validate_hostname "$HOSTNAME"; then
             break
@@ -205,9 +211,15 @@ get_password() {
     local prompt="$1"
     local pass confirm
     while true; do
-        read -rsp "$prompt: " pass; echo
+        if ! read -rsp "$prompt: " pass; then
+            fatal "Input aborted"
+        fi
+        echo
         (( ${#pass} >= 8 )) || { warning "Password must be at least 8 characters long"; continue; }
-        read -rsp "Confirm password: " confirm; echo
+        if ! read -rsp "Confirm password: " confirm; then
+            fatal "Input aborted"
+        fi
+        echo
         [[ "$pass" == "$confirm" ]] || { warning "Passwords do not match"; continue; }
         echo "$pass"
         return 0
@@ -221,7 +233,9 @@ get_root_password() {
 
 get_user_configuration() {
     while true; do
-        read -rp "Enter username for standard user: " USERNAME
+        if ! read -rp "Enter username for standard user: " USERNAME; then
+            fatal "Input aborted"
+        fi
         [[ -n "$USERNAME" ]] || { warning "Username cannot be empty"; continue; }
         if validate_username "$USERNAME"; then
             break
@@ -292,14 +306,18 @@ choose_timezone() {
         fi
     fi
     while true; do
-        read -rp "Enter your timezone (e.g. America/Chicago): " TIMEZONE
+        if ! read -rp "Enter your timezone (e.g. America/Chicago): " TIMEZONE; then
+            fatal "Input aborted"
+        fi
         [[ -f "/usr/share/zoneinfo/$TIMEZONE" ]] && break
         warning "Invalid timezone. Please choose a valid entry from /usr/share/zoneinfo."
     done
 }
 
 configure_swap_size() {
-    read -rp "Enter swap size (e.g. 2G, 512M) [default $SWAP_SIZE]: " size
+    if ! read -rp "Enter swap size (e.g. 2G, 512M) [default $SWAP_SIZE]: " size; then
+        fatal "Input aborted"
+    fi
     if [[ -n "$size" ]]; then
         if [[ "$size" =~ ^[0-9]+[MG]$ ]]; then
             SWAP_SIZE="$size"

--- a/archinstall_new.sh
+++ b/archinstall_new.sh
@@ -59,7 +59,9 @@ yes_no_prompt() {
     local prompt="$1"
     local reply
     while true; do
-        read -rp "$prompt [y/n]: " reply
+        if ! read -rp "$prompt [y/n]: " reply; then
+            fatal "Input aborted"
+        fi
         case "$reply" in
             [Yy]) return 0 ;;
             [Nn]) return 1 ;;
@@ -80,7 +82,9 @@ select_from_menu() {
         for i in "${!options[@]}"; do
             printf '%d) %s\n' "$((i+1))" "${options[i]}"
         done
-        read -rp "Select an option (1-${num}): " choice
+        if ! read -rp "Select an option (1-${num}): " choice; then
+            fatal "Input aborted"
+        fi
         if [[ "$choice" =~ ^[0-9]+$ ]] && (( choice >= 1 && choice <= num )); then
             echo "${options[$((choice-1))]}"
             return 0
@@ -190,7 +194,9 @@ get_btrfs_layout() {
 
 get_hostname() {
     while true; do
-        read -rp "Enter hostname for this system: " HOSTNAME
+        if ! read -rp "Enter hostname for this system: " HOSTNAME; then
+            fatal "Input aborted"
+        fi
         [[ -n "$HOSTNAME" ]] || { warning "Hostname cannot be empty"; continue; }
         if validate_hostname "$HOSTNAME"; then
             break
@@ -205,9 +211,15 @@ get_password() {
     local prompt="$1"
     local pass confirm
     while true; do
-        read -rsp "$prompt: " pass; echo
+        if ! read -rsp "$prompt: " pass; then
+            fatal "Input aborted"
+        fi
+        echo
         (( ${#pass} >= 8 )) || { warning "Password must be at least 8 characters long"; continue; }
-        read -rsp "Confirm password: " confirm; echo
+        if ! read -rsp "Confirm password: " confirm; then
+            fatal "Input aborted"
+        fi
+        echo
         [[ "$pass" == "$confirm" ]] || { warning "Passwords do not match"; continue; }
         echo "$pass"
         return 0
@@ -221,7 +233,9 @@ get_root_password() {
 
 get_user_configuration() {
     while true; do
-        read -rp "Enter username for standard user: " USERNAME
+        if ! read -rp "Enter username for standard user: " USERNAME; then
+            fatal "Input aborted"
+        fi
         [[ -n "$USERNAME" ]] || { warning "Username cannot be empty"; continue; }
         if validate_username "$USERNAME"; then
             break
@@ -292,14 +306,18 @@ choose_timezone() {
         fi
     fi
     while true; do
-        read -rp "Enter your timezone (e.g. America/Chicago): " TIMEZONE
+        if ! read -rp "Enter your timezone (e.g. America/Chicago): " TIMEZONE; then
+            fatal "Input aborted"
+        fi
         [[ -f "/usr/share/zoneinfo/$TIMEZONE" ]] && break
         warning "Invalid timezone. Please choose a valid entry from /usr/share/zoneinfo."
     done
 }
 
 configure_swap_size() {
-    read -rp "Enter swap size (e.g. 2G, 512M) [default $SWAP_SIZE]: " size
+    if ! read -rp "Enter swap size (e.g. 2G, 512M) [default $SWAP_SIZE]: " size; then
+        fatal "Input aborted"
+    fi
     if [[ -n "$size" ]]; then
         if [[ "$size" =~ ^[0-9]+[MG]$ ]]; then
             SWAP_SIZE="$size"


### PR DESCRIPTION
## Summary
- abort on closed stdin in yes/no prompts
- exit if host/user/timezone prompts can't read input
- fail fast on swap size or menu input closures

## Testing
- `bash test_archinstall.sh` *(exits immediately before running tests)*
- `bash -c 'source archinstall.sh; yes_no_prompt "Continue?"' < /dev/null`
- `bash -c 'source archinstall.sh; get_user_configuration' < /dev/null`
- `bash -c 'source archinstall.sh; select_from_menu "Choose:" one two' < /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_6896bcc29a2c8328bf6acc0544606412