### PR TITLE
Refine disk detection

### DIFF
--- a/archinstall.sh
+++ b/archinstall.sh
@@ -135,6 +135,7 @@ get_disk_selection() {
     local labels=()
 
     while IFS= read -r line; do
+        line="${line% disk}"
         local name size model
         name=$(awk '{print $1}' <<< "$line")
         size=$(awk '{print $2}' <<< "$line")
@@ -143,7 +144,7 @@ get_disk_selection() {
             disks+=("/dev/$name")
             labels+=("$name ($size) - $model")
         fi
-    done < <(lsblk -d -n -o NAME,SIZE,MODEL | grep -E "sd[a-z]|nvme[0-9]+n[0-9]+|vd[a-z]")
+    done < <(lsblk -dn -o NAME,SIZE,MODEL,TYPE | awk '$4 == "disk"')
 
     if [[ ${#disks[@]} -eq 0 ]]; then
         fatal "No suitable disks found"

--- a/archinstall_new.sh
+++ b/archinstall_new.sh
@@ -135,6 +135,7 @@ get_disk_selection() {
     local labels=()
 
     while IFS= read -r line; do
+        line="${line% disk}"
         local name size model
         name=$(awk '{print $1}' <<< "$line")
         size=$(awk '{print $2}' <<< "$line")
@@ -143,7 +144,7 @@ get_disk_selection() {
             disks+=("/dev/$name")
             labels+=("$name ($size) - $model")
         fi
-    done < <(lsblk -d -n -o NAME,SIZE,MODEL | grep -E "sd[a-z]|nvme[0-9]n[0-9]|vd[a-z]")
+    done < <(lsblk -dn -o NAME,SIZE,MODEL,TYPE | awk '$4 == "disk"')
 
     if [[ ${#disks[@]} -eq 0 ]]; then
         fatal "No suitable disks found"

--- a/test_config.sh
+++ b/test_config.sh
@@ -120,18 +120,15 @@ USER_SHELLS=(
 # lsblk output variations
 MOCK_LSBLK_SIMPLE="sda sdb nvme0n1"
 
-MOCK_LSBLK_DETAILED="NAME        SIZE TYPE
-sda        100G disk
-├─sda1     512M part
-├─sda2       2G part
-└─sda3    97.5G part
-sdb         50G disk
-nvme0n1    250G disk"
+MOCK_LSBLK_DETAILED="NAME        SIZE MODEL     TYPE
+sda        100G MockDisk disk
+sdb         50G MockDisk disk
+nvme0n1    250G MockNVMe disk"
 
 MOCK_LSBLK_EMPTY=""
 
-MOCK_LSBLK_SINGLE_DISK="NAME        SIZE TYPE
-sda        100G disk"
+MOCK_LSBLK_SINGLE_DISK="NAME        SIZE MODEL     TYPE
+sda        100G MockDisk disk"
 
 # blkid output variations
 MOCK_BLKID_OUTPUT="/dev/sda1: UUID=\"1234-5678\" TYPE=\"vfat\" PARTUUID=\"abcd-1234\"


### PR DESCRIPTION
## Summary
- broaden disk detection to include any block device of type `disk`
- ensure mock test environment reflects new disk query and network check approach

## Testing
- `bash test_archinstall.sh >/tmp/test_archinstall.log`
- `tail -n 20 /tmp/test_archinstall.log`
- `bash test_config.sh >/tmp/test_config.log`
- `tail -n 20 /tmp/test_config.log`

------
https://chatgpt.com/codex/tasks/task_e_6896bcb0df2c8328bf0fb9ffb1abcd89