### PR TITLE
Add root privilege and dependency checks

### DIFF
--- a/archinstall.sh
+++ b/archinstall.sh
@@ -52,6 +52,24 @@ fatal() {
 }
 
 #######################################
+# Pre-flight checks
+#######################################
+require_root() {
+    if [[ "$EUID" -ne 0 ]]; then
+        fatal "This script must be run as root"
+    fi
+}
+
+check_dependencies() {
+    local deps=(lsblk curl sgdisk partprobe pacstrap arch-chroot)
+    for cmd in "${deps[@]}"; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            fatal "Required command '$cmd' not found"
+        fi
+    done
+}
+
+#######################################
 # Prompt helpers
 #######################################
 yes_no_prompt() {
@@ -550,6 +568,8 @@ cleanup() {
 }
 
 main() {
+    require_root
+    check_dependencies
     trap cleanup EXIT
     info "Starting Arch Linux installation"
     validate_uefi_boot


### PR DESCRIPTION
## Summary
- Ensure the installer exits when not run as root
- Verify required tools are available before running

## Testing
- `bash test_archinstall.sh` *(failed: only initial setup messages printed, further tests did not run)*
- `./archinstall.sh` *(fails: Required command 'sgdisk' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896bca6bad083288625fcc2baadbb92