### PR TITLE
Add curl-based network validation with ping fallback

### DIFF
--- a/archinstall.sh
+++ b/archinstall.sh
@@ -101,10 +101,29 @@ validate_uefi_boot() {
 
 validate_network() {
     info "Checking network connectivity..."
-    if ! curl --silent --head --fail https://archlinux.org/ >/dev/null; then
+
+    if command -v curl >/dev/null 2>&1; then
+        if curl --max-time 10 --silent --head --fail https://archlinux.org/ >/dev/null; then
+            success "Network connectivity confirmed"
+            return 0
+        else
+            warning "curl check failed; attempting ping..."
+            if ! command -v ping >/dev/null 2>&1; then
+                fatal "Network check failed with curl and ping is not installed."
+            fi
+        fi
+    else
+        warning "curl not found; falling back to ping..."
+        if ! command -v ping >/dev/null 2>&1; then
+            fatal "Neither curl nor ping is available. Please install curl or iputils."
+        fi
+    fi
+
+    if ping -c 1 -W 5 archlinux.org >/dev/null; then
+        success "Network connectivity confirmed"
+    else
         fatal "No internet connection. Please configure networking and try again."
     fi
-    success "Network connectivity confirmed"
 }
 
 validate_disk() {

--- a/archinstall_new.sh
+++ b/archinstall_new.sh
@@ -101,10 +101,29 @@ validate_uefi_boot() {
 
 validate_network() {
     info "Checking network connectivity..."
-    if ! curl --silent --head --fail https://archlinux.org/ >/dev/null; then
+
+    if command -v curl >/dev/null 2>&1; then
+        if curl --max-time 10 --silent --head --fail https://archlinux.org/ >/dev/null; then
+            success "Network connectivity confirmed"
+            return 0
+        else
+            warning "curl check failed; attempting ping..."
+            if ! command -v ping >/dev/null 2>&1; then
+                fatal "Network check failed with curl and ping is not installed."
+            fi
+        fi
+    else
+        warning "curl not found; falling back to ping..."
+        if ! command -v ping >/dev/null 2>&1; then
+            fatal "Neither curl nor ping is available. Please install curl or iputils."
+        fi
+    fi
+
+    if ping -c 1 -W 5 archlinux.org >/dev/null; then
+        success "Network connectivity confirmed"
+    else
         fatal "No internet connection. Please configure networking and try again."
     fi
-    success "Network connectivity confirmed"
 }
 
 validate_disk() {


### PR DESCRIPTION
## Summary
- ensure `curl` is used for network validation with `--max-time 10` and fall back to `ping`
- error when neither `curl` nor `ping` is available
- expand tests to mock `curl` and cover success, fallback, and failure scenarios

## Testing
- `bash test_archinstall.sh` *(fails: exits early after setup)*
- `source test_archinstall.sh; set +e; setup_mocks; source_archinstall_functions; setup_mock_responses; test_validate_network_success_curl`
- `source test_archinstall.sh; set +e; setup_mocks; source_archinstall_functions; setup_mock_responses; test_validate_network_success_ping_fallback`
- `source test_archinstall.sh; set +e; setup_mocks; source_archinstall_functions; setup_mock_responses; test_validate_network_failure`
- `source archinstall.sh; curl() { return 1; }; ping() { return 1; }; validate_network`

------
https://chatgpt.com/codex/tasks/task_e_6896bcae10608328998a3a098e5779f5