### PR TITLE
Improve installer robustness

### DIFF
--- a/test_archinstall.sh
+++ b/test_archinstall.sh
@@ -213,6 +213,12 @@ sda 100G MockDisk disk
 sdb 50G MockDisk disk
 nvme0n1 250G MockNVMe disk
 LSBLK_OUTPUT
+elif [[ "$*" == *"-b -dn -o SIZE /dev/sda"* ]]; then
+    echo "107374182400"
+elif [[ "$*" == *"-b -dn -o SIZE /dev/sdb"* ]]; then
+    echo "53687091200"
+elif [[ "$*" == *"-b -dn -o SIZE /dev/nvme0n1"* ]]; then
+    echo "268435456000"
 else
     echo "sda sdb nvme0n1"
 fi


### PR DESCRIPTION
## Summary
- verify disks have sufficient space before partitioning
- guard pacman configuration and overwrite fstab for cleaner installs
- extend tests to handle disk size checks

## Testing
- `bash test_archinstall.sh`
- `bash test_config.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896d86b5d8c83288642ae775322fc7b